### PR TITLE
Reset timer each round and remove comments

### DIFF
--- a/xenoglyph/lib/src/features/game/application/game_state.dart
+++ b/xenoglyph/lib/src/features/game/application/game_state.dart
@@ -36,6 +36,8 @@ class GameState extends Equatable {
         status = RoundStatus.playing,
         lastChoiceCorrect = null;
 
+  static const _noTimeLeft = Object();
+
   GameState copyWith({
     GameMode? mode,
     Difficulty? difficulty,
@@ -43,7 +45,7 @@ class GameState extends Equatable {
     int? streak,
     bool? isPaused,
     GameRound? round,
-    int? timeLeft,
+    Object? timeLeft = _noTimeLeft,
     RoundStatus? status,
     bool? lastChoiceCorrect,
   }) {
@@ -54,7 +56,7 @@ class GameState extends Equatable {
       streak: streak ?? this.streak,
       isPaused: isPaused ?? this.isPaused,
       round: round ?? this.round,
-      timeLeft: timeLeft ?? this.timeLeft,
+      timeLeft: identical(timeLeft, _noTimeLeft) ? this.timeLeft : timeLeft as int?,
       status: status ?? this.status,
       lastChoiceCorrect: lastChoiceCorrect ?? this.lastChoiceCorrect,
     );


### PR DESCRIPTION
## Summary
- cancel active timer before starting a new round or checking answers so the countdown resets properly
- allow GameState.copyWith to explicitly override timeLeft values
- strip comments from game logic files

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19bee28c0832a9496e6b7320dc958